### PR TITLE
removes the need for a token to login at jupyter notebook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     env_file:
       - ./.env
     environment:
-      - GDB_BASE=http://graphdb:7200/
+      - GDB_BASE="http://graphdb:7200/"
+      - NOTEBOOK_ARGS="--NotebookApp.token=''"
     labels:
       be.vliz.container.project: "LWUA"
       be.vliz.container.group: "services"


### PR DESCRIPTION
solves #2
seems to work -- and just works in combo with the already provides docker/jupyter_url.sh strategy (and the way documentation suggests to use that) 